### PR TITLE
Fetch data from SRA as a backup

### DIFF
--- a/.github/workflows/fastq-dl.yml
+++ b/.github/workflows/fastq-dl.yml
@@ -22,7 +22,7 @@ jobs:
           channels: conda-forge,bioconda,defaults
           channel-priority: strict
           activate-environment: fastq-dl
-          environment-file: environment.yml
+          environment-file: fastq-dl/environment.yml
           auto-update-conda: true
       - name: Staging
         run: |

--- a/.github/workflows/fastq-dl.yml
+++ b/.github/workflows/fastq-dl.yml
@@ -8,12 +8,22 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -el {0}
     steps:
-      - name: Install fastq-dl
-        run: conda create -y -n fastq-dl -c conda-forge -c bioconda executor pigz 'python>=3.6' 'sra-tools>=3.0.1' requests wget
       - uses: actions/checkout@v2
         with:
           path: fastq-dl
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          python-version: '3.10'
+          miniforge-variant: Mambaforge
+          channels: conda-forge,bioconda,defaults
+          channel-priority: strict
+          activate-environment: fastq-dl
+          environment-file: environment.yml
+          auto-update-conda: true
       - name: Staging
         run: |
          echo "${CONDA}/envs/fastq-dl/bin" >> $GITHUB_PATH

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.fastq.gz
 *.json
 .idea
+__pycache__

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.3.0]
+
+### Added
+
+- Shorthand option `-a` for `--max_attempts` and `v` for `--verbose`
+- If metadata is unavailable from ENA, try fetching metadata from SRA using [`pysradb`][pysradb]
+- Provided query is validated against accession regular expressions
+
+[1.3.0]: https://github.com/rpetit3/fastq-dl/compare/v1.2.0...v1.3.0
+[pysradb]: https://github.com/saketkc/pysradb

--- a/environment.yml
+++ b/environment.yml
@@ -8,3 +8,4 @@ dependencies:
   - sra-tools >=3.0.1
   - wget
   - requests
+  - pysradb >=1.0

--- a/fastq-dl.py
+++ b/fastq-dl.py
@@ -14,7 +14,7 @@ from executor import ExternalCommand, ExternalCommandFailed
 from pysradb import SRAweb
 
 PROGRAM = "fastq-dl"
-VERSION = "1.2.0"
+VERSION = "1.3.0"
 STDOUT = 11
 STDERR = 12
 ENA_FAILED = "ENA_NOT_FOUND"

--- a/fastq-dl.py
+++ b/fastq-dl.py
@@ -4,13 +4,14 @@ import hashlib
 import json
 import logging
 import os
+import re
 import sys
 import time
 from pathlib import Path
-from uuid import uuid4
 
 import requests
 from executor import ExternalCommand, ExternalCommandFailed
+from pysradb import SRAweb
 
 PROGRAM = "fastq-dl"
 VERSION = "1.2.0"
@@ -18,6 +19,8 @@ STDOUT = 11
 STDERR = 12
 ENA_FAILED = "ENA_NOT_FOUND"
 SRA_FAILED = "SRA_NOT_FOUND"
+SRA = "SRA"
+ENA = "ENA"
 MB = 1_048_576
 BUFFER_SIZE = 10 * MB
 logging.addLevelName(STDOUT, "STDOUT")
@@ -240,10 +243,10 @@ def download_ena_fastq(ftp, outdir, md5, max_attempts=10, ftp_only=False):
         Path(outdir).mkdir(parents=True, exist_ok=True)
 
         while not success:
-            logging.info(f"\t\t{os.path.basename(ftp)} FTP download attempt {attempt + 1}")
-            execute(
-                f"wget --quiet -O {fastq} ftp://{ftp}", max_attempts=max_attempts
+            logging.info(
+                f"\t\t{os.path.basename(ftp)} FTP download attempt {attempt + 1}"
             )
+            execute(f"wget --quiet -O {fastq} ftp://{ftp}", max_attempts=max_attempts)
 
             fastq_md5 = md5sum(fastq)
             if fastq_md5 != md5:
@@ -279,8 +282,18 @@ def merge_runs(runs, output):
         Path(runs[0]).rename(output)
 
 
-def get_run_info(query):
-    """Retreive a list of unprocessed samples avalible from ENA."""
+def get_sra_metadata(query: str):
+    # try fetch info from SRA
+    db = SRAweb()
+    df = db.search_sra(
+        query, detailed=True, sample_attribute=True, expand_sample_attributes=True
+    )
+    if df is None:
+        return [False, []]
+    return [True, df.to_dict(orient="records")]
+
+
+def get_ena_metadata(query: str):
     url = f'{ENA_URL}&query="{query}"&fields={",".join(FIELDS)}'
     headers = {"Content-type": "application/x-www-form-urlencoded"}
     r = requests.get(url, headers=headers)
@@ -297,6 +310,24 @@ def get_run_info(query):
         return [True, data]
     else:
         return [False, [r.status_code, r.text]]
+
+
+def get_run_info(query):
+    """Retreive a list of unprocessed samples avalible from ENA."""
+    logging.debug("Quering ENA for metadata...")
+    success, ena_data = get_ena_metadata(query)
+    if success:
+        return ENA, ena_data
+    else:
+        logging.debug("Failed to get metadata from ENA. Trying SRA...")
+        success, sra_data = get_sra_metadata(query.split("=")[1])
+        if not success:
+            logging.error("There was an issue querying ENA and SRA, exiting...")
+            logging.error(f"STATUS: {ena_data[0]}")
+            logging.error(f"TEXT: {ena_data[1]}")
+            sys.exit(1)
+        else:
+            return SRA, sra_data
 
 
 def write_json(data, output):
@@ -324,6 +355,23 @@ def parse_query(query, is_study, is_experiment, is_run):
             return f"study_accession={query}"
 
 
+def validate_query(s: str) -> str:
+    """Check that query is a valid experment, project, or run accession
+    https://ena-docs.readthedocs.io/en/latest/submit/general-guide/accessions.html?highlight=accessions
+    """
+    project_re = re.compile(r"PRJ[EDN][A-Z][0-9]+")
+    study_re = re.compile(r"[EDS]RP[0-9]{6,}")
+    experiment_re = re.compile(r"[EDS]RX[0-9]{6,}")
+    run_re = re.compile(r"[EDS]RR[0-9]{6,}")
+    regexs = [run_re, experiment_re, study_re, project_re]
+    for rx in regexs:
+        if rx.match(s):
+            return s
+    raise argparse.ArgumentTypeError(
+        f"{s} is not a valid project/study/experiment/run accession. See https://ena-docs.readthedocs.io/en/latest/submit/general-guide/accessions.html?highlight=accessions for valid options"
+    )
+
+
 def main():
     parser = argparse.ArgumentParser(
         prog=PROGRAM,
@@ -334,7 +382,7 @@ def main():
     group1.add_argument(
         "query",
         metavar="ACCESSION",
-        type=str,
+        type=validate_query,
         help="ENA/SRA accession to query. (Study, Experiment, or " "Run accession)",
     )
     group1.add_argument(
@@ -381,6 +429,7 @@ def main():
         help="Prefix to use for naming log files [default: %(default)s]",
     )
     group4.add_argument(
+        "-a",
         "--max_attempts",
         metavar="INT",
         type=int,
@@ -413,7 +462,7 @@ def main():
         "--silent", action="store_true", help="Only critical errors will be printed."
     )
     group4.add_argument(
-        "--verbose", action="store_true", help="Print debug related text."
+        "-v", "--verbose", action="store_true", help="Print debug related text."
     )
     group4.add_argument(
         "--debug",
@@ -440,12 +489,7 @@ def main():
     query = parse_query(args.query, args.is_study, args.is_experiment, args.is_run)
 
     # Start Download Process
-    success, ena_data = get_run_info(query)
-    if not success:
-        logging.error("There was an issue querying ENA, exiting...")
-        logging.error(f"STATUS: {ena_data[0]}")
-        logging.error(f"TEXT: {ena_data[1]}")
-        sys.exit(1)
+    data_from, ena_data = get_run_info(query)
 
     logging.info(f"Query: {args.query}")
     logging.info(f"Archive: {args.provider}")
@@ -461,7 +505,7 @@ def main():
             continue
         logging.info(f"\tWorking on run {run_acc}...")
         fastqs = None
-        if args.provider == "ena":
+        if args.provider == "ena" and data_from == ENA:
             fastqs = ena_download(
                 run_info,
                 outdir,
@@ -497,8 +541,8 @@ def main():
                 max_attempts=args.max_attempts,
             )
             if fastqs == SRA_FAILED:
-                if args.sra_only or args.only_provider:
-                    logging.error(f"\t{run_acc} not found on SRA")
+                if args.sra_only or args.only_provider or data_from == SRA:
+                    logging.error(f"\t{run_acc} not found on SRA or ENA")
                     ena_data[i]["error"] = SRA_FAILED
                     fastqs = None
                 else:


### PR DESCRIPTION
## [1.3.0]

### Added

- Shorthand option `-a` for `--max_attempts` and `v` for `--verbose`
- If metadata is unavailable from ENA, try fetching metadata from SRA using [`pysradb`][pysradb]
- Provided query is validated against accession regular expressions

[1.3.0]: https://github.com/rpetit3/fastq-dl/compare/v1.2.0...v1.3.0

---

@rpetit3 I hope it's okay that I've added a CHANGELOG also? If not, I can remove it.

The motivation behind this PR is that I am trying to download some recent data that was submitted to the SRA, but hasn't shown up on the ENA yet. As such, fastq-dl was failing because it couldn't fetch metadata from the ENA.

`pysradb` can be very slow if the query isn't an accession (it just performs a free-form text search), so I added a query validation to the CLI parser, so fastq-dl wont accept a query that doesn't confirm to the study, experiment, run, or project accession regular expressions listed [here](https://ena-docs.readthedocs.io/en/latest/submit/general-guide/accessions.html?#accession-numbers) - which is nice to have anyway I guess?

It also raised a question I have: is it intentional that fastq-dl doesn't support sample accessions?

Anyway, hope this PR is within the scope of the project and do let me know if you want me to change anything.

PS: I have tested this out on the new data I was trying to download.