### PR TITLE
changes to error handling and SRA downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ fastq-dl --help
 
 *fastq-dl* requires a single ENA/SRA Study, Sample, Experiment, or Run accession and FASTQs
 for all Runs that fall under the given accession will be downloaded. For example, if a Study
-accession is given all Runs under that studies umbrella will be downloaded. Which archive to
-download from, either *ENA* or *SRA*, is also required.
+accession is given all Runs under that studies umbrella will be downloaded. By default, 
+`fastq-dl` will try to download from ENA first, then SRA.
 
 ### --accession
 

--- a/fastq_dl/fastq_dl.py
+++ b/fastq_dl/fastq_dl.py
@@ -4,7 +4,6 @@ import hashlib
 import logging
 import re
 import sys
-import os
 import time
 from pathlib import Path
 
@@ -190,10 +189,10 @@ def sra_download(
     # remove existing files if force is selected. 
     # TODO: only remove if the MD5 checksum is different.
     if force and Path(se).exists():
-        os.remove(se)
+        Path(se).unlink()
         logging.warning(f"Overwriting existing files!")
     if force and Path(pe).exists():
-        os.remove(pe)
+        Path(pe).unlink()
         logging.warning(f"Overwriting existing files!")
 
     if not Path(se).exists() and not Path(pe).exists():
@@ -221,7 +220,7 @@ def sra_download(
             return outcome
         else:
             execute(f"pigz --force -p {cpus} -n {accession}*.fastq", directory=outdir)
-            os.remove(f"{outdir}/{accession}.sra")
+            Path(f"{outdir}/{accession}.sra").unlink()
 
     if Path(f"{outdir}/{accession}_2.fastq.gz").exists():
         # Paired end
@@ -350,7 +349,7 @@ def download_ena_fastq(
         if fastq_md5 != md5:
             # the existing file does not match.
             logging.warning(f"MD5 checksums do not match! {md5} vs {fastq_md5} Overwriting existing files.")
-            os.remove(fastq)
+            Path(fastq).unlink()
 
     if not Path(fastq).exists():
         Path(outdir).mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Hi,

Thanks very much for developing such a useful tool!

The ENA ftp server seemed to go down the other day and I noticed that `fastq-dl` was crashing rather than reverting to an SRA download. I've attempted to add a fix for this and have also added some other changes to the way SRA downloads are handled to avoid the temporary `.sra` files from being stored in the default chache directory. 

In summary this pull request

- changes the behaviour of ENA download to swap to SRA if any error is thrown.
- swaps to using `prefetch` followed by `fasterq-dump` when downloading using the SRA
- swaps to using the `--split-3 --mem 1G` parameters in `fasterq-dump`. This should avoid cases of orphaned reads appearing in paired end files and hopefully increase the speed a bit (not tested).
- adds a `--force` option that will overwrite files if they already exist and if the checksum does not match (in the case of ENA downloads).

I have only done some fairly limited testing so it is probably worth double checking that I haven't broken anything. I'm also not 100% sure I have been running the tool correctly so apologies if any of these changes were not necessary.