### PR TITLE
Update search fields for latest ENA API

### DIFF
--- a/fastq_dl/fastq_dl.py
+++ b/fastq_dl/fastq_dl.py
@@ -44,61 +44,7 @@ ENA_FAILED = "ENA_NOT_FOUND"
 SRA_FAILED = "SRA_NOT_FOUND"
 SRA = "SRA"
 ENA = "ENA"
-
 ENA_URL = "https://www.ebi.ac.uk/ena/portal/api/search?result=read_run&format=tsv"
-FIELDS = [
-    "study_accession",
-    "secondary_study_accession",
-    "sample_accession",
-    "secondary_sample_accession",
-    "experiment_accession",
-    "run_accession",
-    "submission_accession",
-    "tax_id",
-    "scientific_name",
-    "instrument_platform",
-    "instrument_model",
-    "library_name",
-    "library_layout",
-    "nominal_length",
-    "library_strategy",
-    "library_source",
-    "library_selection",
-    "read_count",
-    "base_count",
-    "center_name",
-    "first_public",
-    "last_updated",
-    "experiment_title",
-    "study_title",
-    "study_alias",
-    "experiment_alias",
-    "run_alias",
-    "fastq_bytes",
-    "fastq_md5",
-    "fastq_ftp",
-    "fastq_aspera",
-    "fastq_galaxy",
-    "submitted_bytes",
-    "submitted_md5",
-    "submitted_ftp",
-    "submitted_aspera",
-    "submitted_galaxy",
-    "submitted_format",
-    "sra_bytes",
-    "sra_md5",
-    "sra_ftp",
-    "sra_aspera",
-    "sra_galaxy",
-    "cram_index_ftp",
-    "cram_index_aspera",
-    "cram_index_galaxy",
-    "sample_alias",
-    "broker_name",
-    "sample_title",
-    "nominal_sdev",
-    "first_created",
-]
 
 
 def execute(
@@ -373,6 +319,7 @@ def get_sra_metadata(query: str) -> list:
 
 def get_ena_metadata(query: str) -> list:
     """Fetch metadata from ENA.
+    https://docs.google.com/document/d/1CwoY84MuZ3SdKYocqssumghBF88PWxUZ/edit#heading=h.ag0eqy2wfin5
 
     Args:
         query (str): The query to search for.
@@ -380,7 +327,7 @@ def get_ena_metadata(query: str) -> list:
     Returns:
         list: Records associated with the accession.
     """
-    url = f'{ENA_URL}&query="{query}"&fields={",".join(FIELDS)}'
+    url = f'{ENA_URL}&query="{query}"&fields=all'
     headers = {"Content-type": "application/x-www-form-urlencoded"}
     r = requests.get(url, headers=headers)
     if r.status_code == requests.codes.ok:


### PR DESCRIPTION
Closes #15. We just use 'all' search fields now so as not to get errors when search terms are removed/changed.