### PR TITLE
bump to v4.0.0 - replace sra-tools with sracha-rs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -43,6 +43,7 @@
         "SAMEA",
         "SAMN",
         "shlex",
+        "sracha",
         "taiki",
         "testpaths",
         "unioned",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `--gzip-level` option to control gzip compression level for SRA downloads (1-9, default 1)
 
+### Fixed
+
+- Pinned pytest lower bound to >=9.0.3 to address vulnerable tmpdir handling (dependabot #28)
+
 ### Removed
 
 - Dependency on sra-tools (prefetch, fasterq-dump, vdb-config) and pigz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.0] - 2026-05-15
+
+### Changed
+
+- **BREAKING**: Replaced sra-tools (prefetch, fasterq-dump, vdb-config, pigz) with [sracha](https://github.com/rnabioco/sracha-rs), a pure-Rust SRA downloader and FASTQ converter (4-11x faster, no C dependencies)
+- `--ignore` flag now maps to `--no-strict` for SRA downloads (relaxes integrity checks) instead of skipping MD5 verification
+- `--cpus` now controls both thread count and HTTP connection count for SRA downloads
+
+### Added
+
+- `--gzip-level` option to control gzip compression level for SRA downloads (1-9, default 1)
+
+### Removed
+
+- Dependency on sra-tools (prefetch, fasterq-dump, vdb-config) and pigz
+- Support for legacy sequencing platforms (454, SOLiD, Ion Torrent) via SRA provider -- sracha does not support these
+
+[4.0.0]: https://github.com/rpetit3/fastq-dl/compare/v3.1.1...v4.0.0
+
 ## [3.1.1] - 2026-05-14
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,7 +143,7 @@ Exit codes: `1` = validation/provider/download error, `2` = empty result/not fou
 - `sra_download(accession, outdir, ...)` — Uses sracha get for download, conversion, and compression
 
 ### utils.py
-- `execute(cmd, ...)` — Subprocess wrapper with retries and SRA-specific error handling (exit code 3 = not found)
+- `execute(cmd, ...)` — Subprocess wrapper with retries and SRA-specific stderr-based not-found detection
 - `md5sum(fastq)` — Calculates MD5 in 10MB chunks
 - `merge_runs(runs, output)` — Concatenates FASTQs, validates all files exist first
 - `validate_query(query)` — Regex validation for accession types (Project, Study, BioSample, Sample, Experiment, Run)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 **fastq-dl** is a Python CLI tool for downloading FASTQ sequencing files from the European Nucleotide Archive (ENA) or Sequence Read Archive (SRA). It accepts various accession types (Project, Study, BioSample, Sample, Experiment, Run) and handles provider fallback, retry logic, and optional run merging.
 
-- **Version**: 3.1.0
+- **Version**: 4.0.0
 - **License**: MIT
 - **Python**: >=3.10, <3.14
 - **Repository**: https://github.com/rpetit3/fastq-dl
@@ -47,7 +47,7 @@ fastq-dl/
 │   │   ├── __init__.py
 │   │   ├── generic.py           # Provider coordination and fallback
 │   │   ├── ena.py               # ENA downloads via wget (FTP or HTTPS)
-│   │   └── sra.py               # SRA downloads via sra-tools
+│   │   └── sra.py               # SRA downloads via sracha
 │   ├── constants.py             # Shared constants (URLs, suffixes, sentinels)
 │   ├── exceptions.py            # Custom exception hierarchy (8 types)
 │   └── utils.py                 # Utilities (execute, md5sum, merge_runs, write_tsv)
@@ -99,7 +99,7 @@ fastq-dl/
 
 ### Provider Pattern
 - **ENA**: Uses HTTP API for metadata, wget for FTP/HTTPS downloads, MD5 validation
-- **SRA**: Uses pysradb for metadata, prefetch + fasterq-dump for downloads, pigz for compression
+- **SRA**: Uses pysradb for metadata, sracha for download + FASTQ conversion + compression
 - Automatic fallback between providers (configurable with `--provider` and `--only-provider`)
 
 ### Entry Point
@@ -140,7 +140,7 @@ Exit codes: `1` = validation/provider/download error, `2` = empty result/not fou
 
 ### providers/sra.py
 - `get_sra_metadata(query)` — Queries SRA via pysradb, returns `[success: bool, data]`
-- `sra_download(accession, outdir, ...)` — Uses prefetch + fasterq-dump + optional pigz compression
+- `sra_download(accession, outdir, ...)` — Uses sracha get for download, conversion, and compression
 
 ### utils.py
 - `execute(cmd, ...)` — Subprocess wrapper with retries and SRA-specific error handling (exit code 3 = not found)
@@ -194,7 +194,8 @@ Organized into groups via `click.rich_click.OPTION_GROUPS`:
 | `--provider` | `ena` | Provider to use (ena or sra) |
 | `--protocol` | `ftp` | Protocol for ENA downloads (ftp or https) |
 | `--sra-lite` | off | Use SRA Lite (compressed quality scores) |
-| `--skip-compression` | off | Skip pigz compression of SRA downloads |
+| `--skip-compression` | off | Skip compression of SRA downloads |
+| `--gzip-level` | 1 | Gzip compression level for SRA downloads (1-9) |
 
 ### Download Options
 | Option | Short | Default | Description |
@@ -204,7 +205,7 @@ Organized into groups via `click.rich_click.OPTION_GROUPS`:
 | `--only-download-metadata` | | off | Skip downloads, retrieve metadata only |
 | `--group-by-experiment` | | off | Group and merge runs by experiment accession |
 | `--group-by-sample` | | off | Group and merge runs by sample accession |
-| `--ignore` | `-I` | off | Skip MD5 checksum validation |
+| `--ignore` | `-I` | off | Skip MD5 validation (ENA) or relax integrity checks (SRA) |
 
 ### Additional Options
 | Option | Short | Default | Description |
@@ -221,10 +222,7 @@ Organized into groups via `click.rich_click.OPTION_GROUPS`:
 
 Required at runtime (install via conda/environment.yml):
 - `wget` — FTP/HTTPS downloads (ENA)
-- `prefetch` — SRA file download (from sra-tools)
-- `fasterq-dump` — SRA to FASTQ conversion (from sra-tools)
-- `vdb-config` — SRA configuration (from sra-tools)
-- `pigz` — Parallel gzip compression
+- `sracha` — SRA download, FASTQ conversion, and compression (from sracha-rs)
 
 ## Testing
 
@@ -359,11 +357,11 @@ just tag  # Prints commands to run
 
 1. **ENA API**: Returns TSV format, queries use `fields=all`
 2. **SRA Lite**: Compressed quality scores, enabled via `--sra-lite` flag
-3. **Paired-end detection**: ENA uses `library_layout` field; SRA uses `fasterq-dump --split-3`
+3. **Paired-end detection**: ENA uses `library_layout` field; SRA uses sracha `--split split-3` (default)
 4. **Orphan reads**: SRA can produce orphan reads file from paired-end data
-5. **MD5 validation**: Enabled by default, skip with `--ignore` flag
+5. **MD5 validation**: ENA validates by default (skip with `--ignore`); SRA (sracha) always verifies integrity (`--ignore` maps to `--no-strict`)
 6. **Protocol choice**: ENA supports both FTP (default) and HTTPS via `--protocol`
-7. **Compression skip**: SRA downloads can skip pigz compression via `--skip-compression`
+7. **Compression**: SRA downloads compressed by default via sracha (skip with `--skip-compression`, tune with `--gzip-level`)
 
 ## Catalog and LLM Discovery
 

--- a/environment.yml
+++ b/environment.yml
@@ -3,9 +3,8 @@ channels:
   - bioconda
 dependencies:
   - just
-  - pigz
   - pip
   - poetry
   - python >=3.10,<3.14
-  - sra-tools >3.1.1
+  - sracha
   - wget

--- a/fastq_dl/cli/download.py
+++ b/fastq_dl/cli/download.py
@@ -72,6 +72,7 @@ click.rich_click.OPTION_GROUPS = {
                 "--outdir",
                 "--prefix",
                 "--cpus",
+                "--connections",
                 "--force",
                 "--silent",
                 "--sleep",
@@ -229,7 +230,13 @@ def _check_dependencies(ctx, param, value):
     "--cpus",
     default=4,
     show_default=True,
-    help="Total cpus used for downloading from SRA.",
+    help="Total cpus used for SRA conversion and compression.",
+)
+@click.option(
+    "--connections",
+    default=8,
+    show_default=True,
+    help="HTTP connections per file for SRA downloads.",
 )
 @click.option("--silent", is_flag=True, help="Only critical errors will be printed.")
 @click.option("--verbose", "-v", is_flag=True, help="Print debug related text.")
@@ -251,6 +258,7 @@ def fastqdl(
     only_provider,
     only_download_metadata,
     cpus,
+    connections,
     silent,
     verbose,
     protocol,
@@ -292,6 +300,7 @@ def fastqdl(
             only_provider=only_provider,
             only_download_metadata=only_download_metadata,
             cpus=cpus,
+            connections=connections,
             protocol=protocol,
         )
     except ValidationError as e:
@@ -337,6 +346,7 @@ def _run_download(
     only_provider: bool,
     only_download_metadata: bool,
     cpus: int,
+    connections: int,
     protocol: str = "ftp",
 ) -> None:
     """Internal function that performs the actual download logic.
@@ -410,6 +420,7 @@ def _run_download(
                 ignore_md5=ignore_md5,
                 sleep=sleep,
                 cpus=cpus,
+                connections=connections,
                 sra_lite=sra_lite,
                 skip_compression=skip_compression,
                 gzip_level=gzip_level,
@@ -493,6 +504,7 @@ def _download_with_fallback(
     ignore_md5: bool,
     sleep: int,
     cpus: int,
+    connections: int,
     sra_lite: bool,
     skip_compression: bool,
     gzip_level: int,
@@ -536,6 +548,7 @@ def _download_with_fallback(
             run_acc,
             outdir,
             cpus=cpus,
+            connections=connections,
             max_attempts=max_attempts,
             force=force,
             no_strict=ignore_md5,

--- a/fastq_dl/cli/download.py
+++ b/fastq_dl/cli/download.py
@@ -52,6 +52,7 @@ click.rich_click.OPTION_GROUPS = {
                 "--protocol",
                 "--sra-lite",
                 "--skip-compression",
+                "--gzip-level",
             ],
         },
         {
@@ -108,7 +109,7 @@ def _check_dependencies(ctx, param, value):
         click.echo(
             "Some dependencies are missing. "
             "Install via conda: conda install -c bioconda -c conda-forge "
-            "wget sra-tools pigz"
+            "wget sracha"
         )
 
     ctx.exit(0 if all_found else 1)
@@ -188,7 +189,7 @@ def _check_dependencies(ctx, param, value):
     "--ignore",
     "ignore_md5",
     is_flag=True,
-    help="Ignore MD5 checksums for downloaded files.",
+    help="Skip MD5 validation (ENA) or relax integrity checks (SRA).",
 )
 @click.option(
     "--protocol",
@@ -205,7 +206,14 @@ def _check_dependencies(ctx, param, value):
 @click.option(
     "--skip-compression",
     is_flag=True,
-    help="Skip pigz compression of SRA downloads.",
+    help="Skip compression of SRA downloads.",
+)
+@click.option(
+    "--gzip-level",
+    default=1,
+    show_default=True,
+    type=click.IntRange(1, 9),
+    help="Gzip compression level for SRA downloads (1=fast, 9=best).",
 )
 @click.option(
     "--only-provider",
@@ -239,6 +247,7 @@ def fastqdl(
     ignore_md5,
     sra_lite,
     skip_compression,
+    gzip_level,
     only_provider,
     only_download_metadata,
     cpus,
@@ -279,6 +288,7 @@ def fastqdl(
             ignore_md5=ignore_md5,
             sra_lite=sra_lite,
             skip_compression=skip_compression,
+            gzip_level=gzip_level,
             only_provider=only_provider,
             only_download_metadata=only_download_metadata,
             cpus=cpus,
@@ -323,6 +333,7 @@ def _run_download(
     ignore_md5: bool,
     sra_lite: bool,
     skip_compression: bool,
+    gzip_level: int,
     only_provider: bool,
     only_download_metadata: bool,
     cpus: int,
@@ -401,6 +412,7 @@ def _run_download(
                 cpus=cpus,
                 sra_lite=sra_lite,
                 skip_compression=skip_compression,
+                gzip_level=gzip_level,
                 protocol=protocol,
             )
 
@@ -483,6 +495,7 @@ def _download_with_fallback(
     cpus: int,
     sra_lite: bool,
     skip_compression: bool,
+    gzip_level: int,
     protocol: str = "ftp",
 ) -> tuple:
     """Download FASTQs with fallback to alternate provider.
@@ -495,10 +508,12 @@ def _download_with_fallback(
         only_provider: If True, do not fallback to alternate provider
         max_attempts: Maximum download attempts
         force: Overwrite existing files
-        ignore_md5: Skip MD5 verification
+        ignore_md5: Skip MD5 verification (ENA) or relax integrity checks (SRA)
         sleep: Sleep time between retries
         cpus: Number of CPUs for SRA download
         sra_lite: Use SRA Lite format
+        skip_compression: Skip compression of SRA downloads
+        gzip_level: Gzip compression level for SRA downloads (1-9)
         protocol: Protocol for ENA downloads (ftp or https)
 
     Returns:
@@ -523,10 +538,11 @@ def _download_with_fallback(
             cpus=cpus,
             max_attempts=max_attempts,
             force=force,
-            ignore_md5=ignore_md5,
+            no_strict=ignore_md5,
             sleep=sleep,
             sra_lite=sra_lite,
             compress=not skip_compression,
+            gzip_level=gzip_level,
         )
 
     ena_failures = {ENA_FAILED, ENA_NO_FASTQS}

--- a/fastq_dl/constants.py
+++ b/fastq_dl/constants.py
@@ -32,5 +32,5 @@ MERGED_R2_SUFFIX = "_R2.fastq.gz"
 # External tool dependencies grouped by provider
 EXTERNAL_DEPENDENCIES = {
     "ENA": ["wget"],
-    "SRA": ["prefetch", "fasterq-dump", "vdb-config", "pigz"],
+    "SRA": ["sracha"],
 }

--- a/fastq_dl/providers/sra.py
+++ b/fastq_dl/providers/sra.py
@@ -1,7 +1,4 @@
-import glob
 import logging
-import os
-import shutil
 import time
 from pathlib import Path
 from typing import Union
@@ -58,30 +55,33 @@ def sra_download(
     cpus: int = 1,
     max_attempts: int = 10,
     force: bool = False,
-    ignore_md5: bool = False,
+    no_strict: bool = False,
     sleep: int = 10,
     sra_lite: bool = False,
     compress: bool = True,
+    gzip_level: int = 1,
 ) -> Union[dict, str]:
-    """Download FASTQs from SRA using fasterq-dump.
+    """Download FASTQs from SRA using sracha.
 
     Args:
-        accession (str): The accession to download associated FASTQs.
-        outdir (str): Directory to write FASTQs to.
-        cpus (int, optional): Number of CPUs to use. Defaults to 1.
-        max_attempts (int, optional): Maximum number of download attempts. Defaults to 10.
-        force (bool, optional): Force overwrite of existing files
-        ignore_md5 (bool, optional): Ignore MD5 checksums for downloaded files
-        sleep (int, default = 10): Amount of seconds to sleep in between attempts
-        sra_lite (bool, optional): If True, prefer SRA Lite downloads
+        accession: The accession to download associated FASTQs.
+        outdir: Directory to write FASTQs to.
+        cpus: Number of CPUs for download and compression. Defaults to 1.
+        max_attempts: Maximum number of download attempts. Defaults to 10.
+        force: Force overwrite of existing files.
+        no_strict: Downgrade integrity failures to warnings.
+        sleep: Seconds to sleep between retry attempts. Defaults to 10.
+        sra_lite: If True, prefer SRA Lite downloads (simplified quality scores).
+        compress: If True, gzip compress output. Defaults to True.
+        gzip_level: Gzip compression level (1-9). Defaults to 1.
 
     Returns:
-        Union[dict, str]: A dictionary of the FASTQs and their paired status, or SRA_FAILED on error.
-            The dict contains:
-            - r1 (str): Path to R1 FASTQ file
-            - r2 (str): Path to R2 FASTQ file (empty string if single-end)
-            - single_end (bool): True if single-end, False if paired-end
-            - orphan (str | None): Path to orphan reads file if present (paired-end with unpaired reads)
+        A dictionary of the FASTQs and their paired status, or SRA_FAILED on error.
+        The dict contains:
+        - r1 (str): Path to R1 FASTQ file
+        - r2 (str): Path to R2 FASTQ file (empty string if single-end)
+        - single_end (bool): True if single-end, False if paired-end
+        - orphan (str | None): Path to orphan reads file if present
     """
     outdir = Path(outdir)
     fastqs = {"r1": "", "r2": "", "single_end": True, "orphan": None}
@@ -94,7 +94,6 @@ def sra_download(
         pe1 = outdir / f"{accession}{PE_R1_SUFFIX_UNCOMPRESSED}"
         pe2 = outdir / f"{accession}{PE_R2_SUFFIX_UNCOMPRESSED}"
 
-    # remove existing files if force is selected.
     if force:
         for f in [se, pe1, pe2]:
             if f.exists():
@@ -104,87 +103,49 @@ def sra_download(
     if not se.exists() and not (pe1.exists() and pe2.exists()):
         outdir.mkdir(parents=True, exist_ok=True)
 
-        # Use argument lists instead of string commands to prevent command injection
-        vdb_config_cmd = [
-            "vdb-config",
-            "--simplified-quality-scores",
-            "yes" if sra_lite else "no",
+        sracha_cmd = [
+            "sracha",
+            "get",
+            accession,
+            "-O",
+            str(outdir),
+            "--threads",
+            str(cpus),
+            "--connections",
+            str(cpus),
+            "--no-progress",
+            "-y",
         ]
+
         if sra_lite:
+            sracha_cmd.extend(["--format", "sralite"])
             logging.debug("Setting preference to SRA Lite")
         else:
             logging.debug("Setting preference to SRA Normalized")
 
-        execute(vdb_config_cmd)
-
-        prefetch_cmd = [
-            "prefetch",
-            accession,
-            "--max-size",
-            "10T",
-            "-O",
-            str(outdir),
-            "-f",
-            "yes" if force else "no",
-            "--verify",
-            "no" if ignore_md5 else "yes",
-        ]
-
-        outcome = execute(
-            prefetch_cmd,
-            max_attempts=max_attempts,
-            directory=str(outdir),
-            is_sra=True,
-            sleep=sleep,
-        )
-
-        if outcome == SRA_FAILED:
-            return outcome
-
-        fasterq_dump_cmd = [
-            "fasterq-dump",
-            accession,
-            "--split-3",
-            "--mem",
-            "1G",
-            "--threads",
-            str(cpus),
-        ]
         if force:
-            fasterq_dump_cmd.append("-f")
-        # no need to check MD5 of downloaded fastq as it tests checksums as it reads
-        # ref: https://github.com/ncbi/sra-tools/issues/285#issuecomment-586365769
+            sracha_cmd.append("--force")
+
+        if no_strict:
+            sracha_cmd.append("--no-strict")
+
+        if not compress:
+            sracha_cmd.append("--no-gzip")
+        elif gzip_level != 1:
+            sracha_cmd.extend(["--gzip-level", str(gzip_level)])
 
         outcome = execute(
-            fasterq_dump_cmd,
+            sracha_cmd,
             max_attempts=max_attempts,
             directory=str(outdir),
             is_sra=True,
             sleep=sleep,
         )
 
-        # Get list of download fastq files
-        fastq_files = " ".join(
-            [
-                os.path.basename(f)
-                for f in glob.glob(f"{str(outdir)}/{accession}*.fastq")
-            ]
-        )
-
         if outcome == SRA_FAILED:
             return outcome
-        else:
-            if compress:
-                execute(
-                    f"pigz --force -p {cpus} -n {fastq_files}",
-                    directory=str(outdir),
-                )
-            else:
-                logging.debug("'--skip-compression' provided, skipping compression")
-            sra_cache_dir = outdir / accession
-            if sra_cache_dir.is_dir():
-                shutil.rmtree(sra_cache_dir)
-            logging.info(f"Downloaded FASTQs for {accession}")
+
+        logging.info(f"Downloaded FASTQs for {accession}")
     else:
         if se.exists():
             logging.info(f"Skipping re-download of existing file: {se}")
@@ -193,12 +154,10 @@ def sra_download(
             logging.info(f"Skipping re-download of existing file: {pe2}")
 
     if pe2.exists():
-        # Paired end
         fastqs["r1"] = str(pe1)
         fastqs["r2"] = str(pe2)
         fastqs["single_end"] = False
         if se.exists():
-            # Orphan reads file exists (unpaired reads from paired-end data)
             fastqs["orphan"] = str(se)
     else:
         fastqs["r1"] = str(se)

--- a/fastq_dl/providers/sra.py
+++ b/fastq_dl/providers/sra.py
@@ -53,6 +53,7 @@ def sra_download(
     accession: str,
     outdir: str,
     cpus: int = 1,
+    connections: int = 8,
     max_attempts: int = 10,
     force: bool = False,
     no_strict: bool = False,
@@ -66,7 +67,8 @@ def sra_download(
     Args:
         accession: The accession to download associated FASTQs.
         outdir: Directory to write FASTQs to.
-        cpus: Number of CPUs for download and compression. Defaults to 1.
+        cpus: Number of CPUs for conversion and compression. Defaults to 1.
+        connections: HTTP connections per file for download. Defaults to 8.
         max_attempts: Maximum number of download attempts. Defaults to 10.
         force: Force overwrite of existing files.
         no_strict: Downgrade integrity failures to warnings.
@@ -112,7 +114,7 @@ def sra_download(
             "--threads",
             str(cpus),
             "--connections",
-            str(cpus),
+            str(connections),
             "--no-progress",
             "-y",
         ]

--- a/fastq_dl/utils.py
+++ b/fastq_dl/utils.py
@@ -71,6 +71,10 @@ def execute(
             logging.debug(f"STDOUT: {e.stdout}")
             logging.debug(f"STDERR: {e.stderr}")
 
+            # sracha's Error::NotFound produces stderr "not found: {accession}"
+            # (see rnabioco/sracha-rs error.rs). Unlike sra-tools (exit code 3),
+            # sracha exits 1 for all errors, so we parse stderr to distinguish
+            # "not found" (immediate ENA fallback) from transient failures (retry).
             if is_sra and e.stderr and "not found:" in e.stderr.lower():
                 error_msg = e.stderr.split("\n")[0] if e.stderr else "Unknown error"
                 logging.error(error_msg)

--- a/fastq_dl/utils.py
+++ b/fastq_dl/utils.py
@@ -71,8 +71,7 @@ def execute(
             logging.debug(f"STDOUT: {e.stdout}")
             logging.debug(f"STDERR: {e.stderr}")
 
-            if is_sra and e.returncode == 3:
-                # The FASTQ isn't on SRA for some reason, try to download from ENA
+            if is_sra and e.stderr and "not found:" in e.stderr.lower():
                 error_msg = e.stderr.split("\n")[0] if e.stderr else "Unknown error"
                 logging.error(error_msg)
                 return SRA_FAILED

--- a/poetry.lock
+++ b/poetry.lock
@@ -847,21 +847,21 @@ xmltodict = ">=0.12.0"
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1280,4 +1280,4 @@ test = ["pytest", "pytest-cov"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.14"
-content-hash = "026144a8224d5243ef89697a4afd77816f76030d4bd54db23ba65210884d6d8f"
+content-hash = "e8c72ff6cb7cf3ceb87ae426a5d5ba41946ee95daa9e2769951a8c2915c4844c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ pandas = "^2.2.3"
 
 [tool.poetry.group.dev.dependencies]
 ruff = ">=0.15"
-pytest = ">=8.3.3,<10.0.0"
+pytest = ">=9.0.3,<10.0.0"
 pytest-cov = "^4.1.0"
 pytest-mock = "^3.12.0"
 responses = "^0.24.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fastq-dl"
-version = "3.1.1"
+version = "4.0.0"
 description = "Download FASTQ files from SRA or ENA repositories."
 authors = [
     "Robert A. Petit III <robbie.petit@gmail.com>",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -488,17 +488,14 @@ class TestCheckDependencies:
         assert result.exit_code == 0
         assert "All dependencies found." in result.output
         assert "wget: Found (/usr/bin/wget)" in result.output
-        assert "prefetch: Found (/usr/bin/prefetch)" in result.output
-        assert "fasterq-dump: Found (/usr/bin/fasterq-dump)" in result.output
-        assert "vdb-config: Found (/usr/bin/vdb-config)" in result.output
-        assert "pigz: Found (/usr/bin/pigz)" in result.output
+        assert "sracha: Found (/usr/bin/sracha)" in result.output
 
     @patch("fastq_dl.cli.download.shutil.which")
     def test_check_some_missing(self, mock_which, runner):
         """Test --check when some tools are missing."""
 
         def which_side_effect(tool):
-            if tool in ("prefetch", "fasterq-dump", "vdb-config"):
+            if tool == "sracha":
                 return None
             return f"/usr/bin/{tool}"
 
@@ -506,7 +503,7 @@ class TestCheckDependencies:
         result = runner.invoke(fastqdl, ["--check"])
         assert result.exit_code == 1
         assert "Some dependencies are missing." in result.output
-        assert "prefetch: Not found" in result.output
+        assert "sracha: Not found" in result.output
         assert "wget: Found" in result.output
 
     @patch("fastq_dl.cli.download.shutil.which")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -332,6 +332,45 @@ class TestCLIOptions:
 
         assert result.exit_code == 0
 
+    @patch("fastq_dl.cli.download.validate_query")
+    @patch("fastq_dl.cli.download.get_run_info")
+    @patch("fastq_dl.cli.download.write_tsv")
+    def test_gzip_level_flag(
+        self, mock_write_tsv, mock_get_run_info, mock_validate_query, runner, tmp_path
+    ):
+        """Test --gzip-level flag is accepted with valid value."""
+        mock_validate_query.return_value = "run_accession=SRR123456"
+        mock_get_run_info.return_value = ("ENA", [])
+
+        result = runner.invoke(
+            fastqdl,
+            [
+                "--accession",
+                "SRR123456",
+                "--gzip-level",
+                "6",
+                "--only-download-metadata",
+                "--outdir",
+                str(tmp_path),
+            ],
+        )
+
+        assert result.exit_code == 0
+
+    def test_gzip_level_invalid(self, runner):
+        """Test --gzip-level rejects out-of-range values."""
+        result = runner.invoke(
+            fastqdl,
+            ["--accession", "SRR123456", "--gzip-level", "0"],
+        )
+        assert result.exit_code != 0
+
+        result = runner.invoke(
+            fastqdl,
+            ["--accession", "SRR123456", "--gzip-level", "10"],
+        )
+        assert result.exit_code != 0
+
 
 class TestExitCodes:
     """Tests for exit codes on download failures."""

--- a/tests/test_providers_sra.py
+++ b/tests/test_providers_sra.py
@@ -67,7 +67,6 @@ class TestSraDownload:
         """Test successful paired-end download from SRA."""
         mock_execute.return_value = 0
 
-        # Create mock output files that would be created by fasterq-dump
         pe1 = tmp_outdir / "SRR123456_1.fastq.gz"
         pe2 = tmp_outdir / "SRR123456_2.fastq.gz"
         pe1.write_bytes(b"read1")
@@ -85,7 +84,6 @@ class TestSraDownload:
         """Test successful single-end download from SRA."""
         mock_execute.return_value = 0
 
-        # Create mock output file
         se = tmp_outdir / "SRR123456.fastq.gz"
         se.write_bytes(b"reads")
 
@@ -100,10 +98,9 @@ class TestSraDownload:
         """Test paired-end download with orphan reads file."""
         mock_execute.return_value = 0
 
-        # Create mock output files including orphan reads
         pe1 = tmp_outdir / "SRR123456_1.fastq.gz"
         pe2 = tmp_outdir / "SRR123456_2.fastq.gz"
-        se = tmp_outdir / "SRR123456.fastq.gz"  # Orphan reads
+        se = tmp_outdir / "SRR123456.fastq.gz"
         pe1.write_bytes(b"read1")
         pe2.write_bytes(b"read2")
         se.write_bytes(b"orphan_reads")
@@ -116,8 +113,8 @@ class TestSraDownload:
         assert result["orphan"] == str(se)
 
     @patch("fastq_dl.providers.sra.execute")
-    def test_prefetch_failure(self, mock_execute, tmp_outdir):
-        """Test handling of prefetch command failure."""
+    def test_download_failure(self, mock_execute, tmp_outdir):
+        """Test handling of sracha command failure."""
         mock_execute.return_value = SRA_FAILED
 
         result = sra_download("SRR123456", str(tmp_outdir))
@@ -126,49 +123,38 @@ class TestSraDownload:
 
     @patch("fastq_dl.providers.sra.execute")
     def test_sra_lite_preference(self, mock_execute, tmp_outdir):
-        """Test --sra-lite flag sets correct preference."""
+        """Test --sra-lite flag passes --format sralite to sracha."""
         se = tmp_outdir / "SRR123456.fastq.gz"
-        sra_file = tmp_outdir / "SRR123456.sra"
 
         def create_output_files(*args, **kwargs):
             se.write_bytes(b"reads")
-            sra_file.write_bytes(b"sra")
             return 0
 
         mock_execute.side_effect = create_output_files
 
         sra_download("SRR123456", str(tmp_outdir), sra_lite=True)
 
-        # Check that vdb-config was called with 'yes'
-        calls = [
-            c[0][0] for c in mock_execute.call_args_list
-        ]  # Get first positional arg of each call
-        assert any(
-            isinstance(c, list) and "vdb-config" in c and "yes" in c for c in calls
-        )
+        cmd = mock_execute.call_args_list[0][0][0]
+        assert "sracha" in cmd
+        assert "--format" in cmd
+        assert "sralite" in cmd
 
     @patch("fastq_dl.providers.sra.execute")
     def test_sra_normalized_preference(self, mock_execute, tmp_outdir):
-        """Test default SRA Normalized preference."""
+        """Test default SRA Normalized preference (no --format sralite)."""
         se = tmp_outdir / "SRR123456.fastq.gz"
-        sra_file = tmp_outdir / "SRR123456.sra"
 
         def create_output_files(*args, **kwargs):
             se.write_bytes(b"reads")
-            sra_file.write_bytes(b"sra")
             return 0
 
         mock_execute.side_effect = create_output_files
 
         sra_download("SRR123456", str(tmp_outdir), sra_lite=False)
 
-        # Check that vdb-config was called with 'no'
-        calls = [
-            c[0][0] for c in mock_execute.call_args_list
-        ]  # Get first positional arg of each call
-        assert any(
-            isinstance(c, list) and "vdb-config" in c and "no" in c for c in calls
-        )
+        cmd = mock_execute.call_args_list[0][0][0]
+        assert "sracha" in cmd
+        assert "sralite" not in cmd
 
     def test_skip_existing_paired_files(self, tmp_outdir):
         """Test skipping download when paired files already exist."""
@@ -201,14 +187,9 @@ class TestSraDownload:
 
         pe1 = tmp_outdir / "SRR123456_1.fastq.gz"
         pe2 = tmp_outdir / "SRR123456_2.fastq.gz"
-        sra_file = tmp_outdir / "SRR123456.sra"
         pe1.write_bytes(b"old")
         pe2.write_bytes(b"old")
-        sra_file.write_bytes(
-            b"sra"
-        )  # Create .sra file that gets unlinked after download
 
-        # Create output files that would be created by fasterq-dump
         def create_output_files(*args, **kwargs):
             pe1.write_bytes(b"new")
             pe2.write_bytes(b"new")
@@ -218,89 +199,80 @@ class TestSraDownload:
 
         sra_download("SRR123456", str(tmp_outdir), force=True)
 
-        # execute should have been called since force=True
         assert mock_execute.called
-
-    @patch("fastq_dl.providers.sra.execute")
-    def test_fasterq_dump_failure(self, mock_execute, tmp_outdir):
-        """Test handling of fasterq-dump command failure."""
-        # First call (vdb-config) succeeds, second call (prefetch) succeeds,
-        # third call (fasterq-dump) fails
-        mock_execute.side_effect = [0, 0, SRA_FAILED]
-
-        result = sra_download("SRR123456", str(tmp_outdir))
-
-        assert result == SRA_FAILED
+        cmd = mock_execute.call_args_list[0][0][0]
+        assert "--force" in cmd
 
     @patch("fastq_dl.providers.sra.execute")
     def test_cpus_parameter(self, mock_execute, tmp_outdir):
-        """Test cpus parameter is passed to fasterq-dump."""
+        """Test cpus parameter is passed to sracha as --threads and --connections."""
         se = tmp_outdir / "SRR123456.fastq.gz"
-        sra_file = tmp_outdir / "SRR123456.sra"
 
         def create_output_files(*args, **kwargs):
             se.write_bytes(b"reads")
-            sra_file.write_bytes(b"sra")
             return 0
 
         mock_execute.side_effect = create_output_files
 
         sra_download("SRR123456", str(tmp_outdir), cpus=4)
 
-        # Get first positional arg of each call
-        calls = [c[0][0] for c in mock_execute.call_args_list]
-        # Check for fasterq-dump command with --threads and 4
-        assert any(
-            isinstance(c, list)
-            and "fasterq-dump" in c
-            and "--threads" in c
-            and "4" in c
-            for c in calls
-        )
+        cmd = mock_execute.call_args_list[0][0][0]
+        assert "sracha" in cmd
+        threads_idx = cmd.index("--threads")
+        assert cmd[threads_idx + 1] == "4"
+        connections_idx = cmd.index("--connections")
+        assert cmd[connections_idx + 1] == "4"
 
     @patch("fastq_dl.providers.sra.execute")
-    def test_ignore_md5_skips_verification(self, mock_execute, tmp_outdir):
-        """Test ignore_md5 flag adds --verify no to prefetch command."""
+    def test_no_strict_passes_flag(self, mock_execute, tmp_outdir):
+        """Test no_strict flag adds --no-strict to sracha command."""
         se = tmp_outdir / "SRR123456.fastq.gz"
-        sra_file = tmp_outdir / "SRR123456.sra"
 
         def create_output_files(*args, **kwargs):
             se.write_bytes(b"reads")
-            sra_file.write_bytes(b"sra")
             return 0
 
         mock_execute.side_effect = create_output_files
 
-        sra_download("SRR123456", str(tmp_outdir), ignore_md5=True)
+        sra_download("SRR123456", str(tmp_outdir), no_strict=True)
 
-        # Get all commands passed to execute
-        calls = [c[0][0] for c in mock_execute.call_args_list]
+        cmd = mock_execute.call_args_list[0][0][0]
+        assert "--no-strict" in cmd
 
-        # Find the prefetch command and verify --verify no is present
-        prefetch_calls = [c for c in calls if isinstance(c, list) and "prefetch" in c]
-        assert len(prefetch_calls) == 1
-        # Check that --verify is followed by no
-        prefetch_cmd = prefetch_calls[0]
-        verify_idx = prefetch_cmd.index("--verify")
-        assert prefetch_cmd[verify_idx + 1] == "no"
+    @patch("fastq_dl.providers.sra.execute")
+    def test_no_strict_not_passed_by_default(self, mock_execute, tmp_outdir):
+        """Test --no-strict is not passed when no_strict=False."""
+        se = tmp_outdir / "SRR123456.fastq.gz"
+
+        def create_output_files(*args, **kwargs):
+            se.write_bytes(b"reads")
+            return 0
+
+        mock_execute.side_effect = create_output_files
+
+        sra_download("SRR123456", str(tmp_outdir), no_strict=False)
+
+        cmd = mock_execute.call_args_list[0][0][0]
+        assert "--no-strict" not in cmd
 
     @patch("fastq_dl.providers.sra.execute")
     def test_skip_compress_produces_uncompressed_files(self, mock_execute, tmp_outdir):
-        """Test compress=False skips pigz and uses .fastq suffixes."""
-        mock_execute.return_value = 0
-
-        # Create mock uncompressed output files
+        """Test compress=False passes --no-gzip and uses .fastq suffixes."""
         se = tmp_outdir / "SRR123456.fastq"
-        se.write_bytes(b"reads")
+
+        def create_output_files(*args, **kwargs):
+            se.write_bytes(b"reads")
+            return 0
+
+        mock_execute.side_effect = create_output_files
 
         result = sra_download("SRR123456", str(tmp_outdir), compress=False)
 
         assert result["r1"] == str(se)
         assert result["single_end"] is True
         assert str(result["r1"]).endswith(".fastq")
-        # pigz should not have been called
-        calls = [c[0][0] for c in mock_execute.call_args_list]
-        assert not any(isinstance(c, str) and "pigz" in c for c in calls)
+        cmd = mock_execute.call_args_list[0][0][0]
+        assert "--no-gzip" in cmd
 
     @patch("fastq_dl.providers.sra.execute")
     def test_skip_compress_paired_end(self, mock_execute, tmp_outdir):
@@ -321,24 +293,55 @@ class TestSraDownload:
         assert str(result["r2"]).endswith("_2.fastq")
 
     @patch("fastq_dl.providers.sra.execute")
-    def test_md5_verification_enabled_by_default(self, mock_execute, tmp_outdir):
-        """Test MD5 verification is enabled by default (--verify yes)."""
+    def test_gzip_level_default(self, mock_execute, tmp_outdir):
+        """Test default gzip level (1) does not add --gzip-level flag."""
         se = tmp_outdir / "SRR123456.fastq.gz"
-        sra_file = tmp_outdir / "SRR123456.sra"
 
         def create_output_files(*args, **kwargs):
             se.write_bytes(b"reads")
-            sra_file.write_bytes(b"sra")
             return 0
 
         mock_execute.side_effect = create_output_files
 
-        sra_download("SRR123456", str(tmp_outdir), ignore_md5=False)
+        sra_download("SRR123456", str(tmp_outdir), gzip_level=1)
 
-        calls = [c[0][0] for c in mock_execute.call_args_list]
-        prefetch_calls = [c for c in calls if isinstance(c, list) and "prefetch" in c]
-        assert len(prefetch_calls) == 1
-        # Check that --verify is followed by yes
-        prefetch_cmd = prefetch_calls[0]
-        verify_idx = prefetch_cmd.index("--verify")
-        assert prefetch_cmd[verify_idx + 1] == "yes"
+        cmd = mock_execute.call_args_list[0][0][0]
+        assert "--gzip-level" not in cmd
+
+    @patch("fastq_dl.providers.sra.execute")
+    def test_gzip_level_custom(self, mock_execute, tmp_outdir):
+        """Test custom gzip level is passed to sracha."""
+        se = tmp_outdir / "SRR123456.fastq.gz"
+
+        def create_output_files(*args, **kwargs):
+            se.write_bytes(b"reads")
+            return 0
+
+        mock_execute.side_effect = create_output_files
+
+        sra_download("SRR123456", str(tmp_outdir), gzip_level=6)
+
+        cmd = mock_execute.call_args_list[0][0][0]
+        gzip_idx = cmd.index("--gzip-level")
+        assert cmd[gzip_idx + 1] == "6"
+
+    @patch("fastq_dl.providers.sra.execute")
+    def test_sracha_command_structure(self, mock_execute, tmp_outdir):
+        """Test the full sracha get command is constructed correctly."""
+        se = tmp_outdir / "SRR123456.fastq.gz"
+
+        def create_output_files(*args, **kwargs):
+            se.write_bytes(b"reads")
+            return 0
+
+        mock_execute.side_effect = create_output_files
+
+        sra_download("SRR123456", str(tmp_outdir), cpus=2)
+
+        cmd = mock_execute.call_args_list[0][0][0]
+        assert cmd[0] == "sracha"
+        assert cmd[1] == "get"
+        assert cmd[2] == "SRR123456"
+        assert "-O" in cmd
+        assert "--no-progress" in cmd
+        assert "-y" in cmd

--- a/tests/test_providers_sra.py
+++ b/tests/test_providers_sra.py
@@ -205,7 +205,7 @@ class TestSraDownload:
 
     @patch("fastq_dl.providers.sra.execute")
     def test_cpus_parameter(self, mock_execute, tmp_outdir):
-        """Test cpus parameter is passed to sracha as --threads and --connections."""
+        """Test cpus parameter is passed to sracha as --threads."""
         se = tmp_outdir / "SRR123456.fastq.gz"
 
         def create_output_files(*args, **kwargs):
@@ -217,11 +217,27 @@ class TestSraDownload:
         sra_download("SRR123456", str(tmp_outdir), cpus=4)
 
         cmd = mock_execute.call_args_list[0][0][0]
-        assert "sracha" in cmd
+        threads_idx = cmd.index("--threads")
+        assert cmd[threads_idx + 1] == "4"
+
+    @patch("fastq_dl.providers.sra.execute")
+    def test_connections_parameter(self, mock_execute, tmp_outdir):
+        """Test connections parameter is passed to sracha as --connections."""
+        se = tmp_outdir / "SRR123456.fastq.gz"
+
+        def create_output_files(*args, **kwargs):
+            se.write_bytes(b"reads")
+            return 0
+
+        mock_execute.side_effect = create_output_files
+
+        sra_download("SRR123456", str(tmp_outdir), cpus=4, connections=12)
+
+        cmd = mock_execute.call_args_list[0][0][0]
         threads_idx = cmd.index("--threads")
         assert cmd[threads_idx + 1] == "4"
         connections_idx = cmd.index("--connections")
-        assert cmd[connections_idx + 1] == "4"
+        assert cmd[connections_idx + 1] == "12"
 
     @patch("fastq_dl.providers.sra.execute")
     def test_no_strict_passes_flag(self, mock_execute, tmp_outdir):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -158,15 +158,15 @@ class TestExecute:
         assert result == ENA_FAILED
 
     @patch("fastq_dl.utils.subprocess.run")
-    def test_sra_exit_code_3_returns_sra_failed(self, mock_run):
-        """Test SRA-specific exit code 3 handling."""
+    def test_sra_not_found_returns_sra_failed(self, mock_run):
+        """Test SRA not-found detection via stderr parsing."""
         mock_run.side_effect = subprocess.CalledProcessError(
-            returncode=3,
-            cmd="prefetch SRR123456",
-            stderr="Item not found\nMore info",
+            returncode=1,
+            cmd="sracha get SRR123456",
+            stderr="not found: SRR123456\nMore info",
         )
 
-        result = execute("prefetch SRR123456", is_sra=True)
+        result = execute("sracha get SRR123456", is_sra=True)
 
         assert result == SRA_FAILED
 


### PR DESCRIPTION
The sra-tools developers to don't officially support the conda install. 

Recently I've run into issues related to SSL certs and GLIBC versions with the conda install of sra-tools.

This PR replaces sra-tools with [sracha-rs](https://rnabioco.github.io/sracha-rs/), a fast SRA downloader and FASTQ converter, written in pure Rust.

It is nearly a drop in replacement for sra-tools, with minimal changes needed.