### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/fastq-dl.yml
+++ b/.github/workflows/fastq-dl.yml
@@ -10,6 +10,9 @@ on:
     - cron: "0 2 * * 0"
   workflow_dispatch: # Allow manual triggers
 
+permissions:
+  contents: read
+
 jobs:
   # Job 1: Fast unit tests on all Python versions
   unit-tests:
@@ -161,6 +164,9 @@ jobs:
   # Job 3: Notify on scheduled run failures
   notify-failure:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     needs: [unit-tests, integration-tests]
     if: failure() && github.event_name == 'schedule'
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'v*.*.*'
 
+permissions:
+  contents: read
+
 jobs:
   build-n-publish:
     name: Build and publish to PyPI


### PR DESCRIPTION
Potential fix for [https://github.com/rpetit3/fastq-dl/security/code-scanning/4](https://github.com/rpetit3/fastq-dl/security/code-scanning/4)

Add explicit `permissions` to enforce least privilege:

1. At workflow root (near `on:`/before `jobs:`), set a restrictive default:
   - `contents: read`
2. At `notify-failure` job level, override/add only what that job needs to create issues:
   - `contents: read`
   - `issues: write`

This preserves current functionality (issue creation still works) while ensuring other jobs do not inherit unnecessary write scopes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
